### PR TITLE
Use include_once to prevent Cannot redeclare class Mascame\URLify error

### DIFF
--- a/src/Mascame/Urlify/UrlifyServiceProvider.php
+++ b/src/Mascame/Urlify/UrlifyServiceProvider.php
@@ -21,7 +21,7 @@ class UrlifyServiceProvider extends ServiceProvider {
 	{
 		$this->package('mascame/urlify');
 
-        include 'URLify.php';
+        include_once 'URLify.php';
 	}
 
 	/**


### PR DESCRIPTION
I got `Cannot redeclare class Mascame\URLify` error when running my tests; this fixes it.
